### PR TITLE
[Issue #31] Remove brackdrop-filter on .workspace

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1304,7 +1304,6 @@ input.prompt-input:hover {
 }
 
 .is-translucent .workspace {
-  backdrop-filter: blur(80px);
   background-color: var(--background-translucent);
 }
 


### PR DESCRIPTION
To allow transparent background to work on windows