### PR TITLE
fix color of titlebar with Hider frameless mode enabled

### DIFF
--- a/src/010-main.css
+++ b/src/010-main.css
@@ -1097,6 +1097,10 @@ body:not(.is-mobile) .titlebar {
   padding-top: 0 !important;
 }
 
+body.hider-frameless:not(.is-mobile) .titlebar {
+  background: transparent;
+}
+
 body.theme-dark:not(.is-mobile) .titlebar {
   background-color: var(--shade-10);
 }


### PR DESCRIPTION
This fixes the titlebar color on desktop when the frameless mode of the Hider plugin is enabled. Tested with Dark theme, too.

Without the fix it looks like this:
<img width="906" alt="Screen Shot 2021-07-16 at 17 18 12" src="https://user-images.githubusercontent.com/6043497/125970607-4cd7daea-d77a-4853-be29-39d9ffcbb171.png">
