### PR TITLE
Fix pending tasks not visible in Calendar plugin

### DIFF
--- a/src/030-icons.css
+++ b/src/030-icons.css
@@ -20,10 +20,6 @@ body.is-mobile {
   --svg-xxl: 24px;
 }
 
-svg {
-  stroke-width: 0;
-}
-
 .view-action > svg,
 .view-header-icon > svg,
 .nav-action-button svg,


### PR DESCRIPTION
Fixes the Calendar plugin, where the pending tasks where not visible anymore. The bug was introduced by [commit cc9e395](https://github.com/mgmeyers/obsidian-california-coast-theme/commit/cc9e3954ea80c204afb54b75ebb4ec4da9e15bee).

Before this fix:
<img width="240" alt="Screen Shot 2021-07-20 at 13 16 00" src="https://user-images.githubusercontent.com/6043497/126315088-d9c081bd-c4ff-47c5-82bb-3a9321a25620.png">

After this fix:
<img width="238" alt="Screen Shot 2021-07-20 at 13 16 21" src="https://user-images.githubusercontent.com/6043497/126315111-ada6ce7e-9988-487f-9645-55942393e1f3.png">