### PR TITLE
fix CJK input issue in list of cm6 editor

### DIFF
--- a/src/050-editor.css
+++ b/src/050-editor.css
@@ -69,6 +69,8 @@
   white-space: pre;
   display: inline-flex;
   justify-content: flex-end;
+}
+.markdown-source-view.mod-cm5 .cm-formatting-list-ol {
   width: 1rem;
 }
 


### PR DESCRIPTION
in an empty number list like `1. `, when entering text with CJK input method, the raw text are considered as a part of cm-formatting-list-ol and all squeezed in a small space.

https://user-images.githubusercontent.com/31102694/144699881-f54da218-96fc-41f6-9e4e-9559f4c228b6.mp4

related: https://canary.discord.com/channels/686053708261228577/908079085257908234/916570566343933982

> Licat: 
> as far as I know, CodeMirror doesn't update its display when you're composing with IME, because if they did that the IME would forget the letters typed and double up
> only when you finish composing it becomes something CodeMirror can manipulate

